### PR TITLE
feat(ci): Auto-mark pre-release tags

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -57,5 +57,6 @@ jobs:
         with:
           name: Kailibrate ${{ github.ref_name }}
           generate_release_notes: true
+          prerelease: ${{ contains(github.ref_name, '-') }}
           files: build/app/outputs/flutter-apk/kailibrate-${{ github.ref_name }}.apk
           fail_on_unmatched_files: true


### PR DESCRIPTION
## Summary
- Adds `prerelease: ${{ contains(github.ref_name, '-') }}` to the GitHub Release action
- Tags like `v0.19.0-beta.1` or `v0.19.0-rc.1` are automatically published with the yellow **Pre-release** label
- Stable tags without a hyphen (e.g., `v0.19.0`) remain full releases

## Test plan
- [x] `v0.19.0-beta.1` was pushed from this branch — CI should produce a Pre-release on GitHub
- [ ] After merge: push `v0.19.0` → verify no Pre-release label

🤖 Generated with [Claude Code](https://claude.com/claude-code)