### PR TITLE
chore: Version kanban tooling and Claude skills

### DIFF
--- a/.claude/skills/kanban-based-development/SKILL.md
+++ b/.claude/skills/kanban-based-development/SKILL.md
@@ -1,0 +1,268 @@
+---
+name: kanban-based-development
+description: >
+  Autonomous, parallel-safe development workflow using kanban-md.
+  Use when the user asks to work through tasks, do kanban-based development,
+  or when multiple agents need to coordinate work on the same codebase.
+  Optimized for explicit handoffs and a "defer to user" protocol when
+  human intervention is required.
+allowed-tools:
+  - Bash(kanban-md *)
+  - Bash(kbmd *)
+  - Bash(git *)
+  - Bash(go *)
+  - Bash(golangci-lint *)
+  - Bash(awk *)
+---
+<!-- kanban-md-skill-version: dev -->
+
+# Kanban-Based Development
+
+Autonomous, parallel-safe development using `kanban-md` to coordinate work on a shared board.
+Claims prevent duplicate work; `review` is the waiting room (handoff, user action, merge, decisions).
+
+## Multi-Agent Environment
+
+**This board is shared.** Multiple agents and humans may be working on it simultaneously. You are NOT the only one reading or modifying tasks. This means:
+
+- Another agent may claim a task between the time you list it and try to pick it.
+- Tasks you saw as available a moment ago may no longer be available.
+
+The **claim** mechanic is the coordination primitive. It prevents two agents from working on the same task. **You MUST claim a task before starting any work on it, and you MUST only pick unclaimed tasks.** Violating this causes duplicate work, merge conflicts, and wasted effort.
+
+## Non-Negotiables
+
+- **Claim before you change anything.** No task edits, no code changes.
+- **One active task per agent.** Keep at most one task in `in-progress` for your agent session.
+- **Never steal a live claim.** If it's claimed, pick something else.
+- **Never release someone else’s claim.** Only use `edit --release` for your own work (or when the user explicitly asks).
+- **Always leave a handoff.** Before you park a task, write a short update in the body so someone else can continue.
+- **Refresh claims to avoid timeout.** If the task might take longer than `claim_timeout`, periodically renew your claim: `kanban-md edit <ID> --claim <agent>`.
+
+## Board Home vs Worktrees (simple rule)
+
+- **Always run `kanban-md` from board home** (the canonical repo directory that owns the shared board).
+- **Always do code changes in a task worktree.** Never edit code in board home.
+- If the board is git-tracked, **commit board changes on `main` as a separate commit** after the task is merged and moved to `done`.
+
+At the start of the session, determine and remember `<board-home>`:
+
+```bash
+cd <the canonical repo directory that owns the shared board>
+pwd   # remember this path as <board-home>
+```
+
+Recommended: keep two shells (or split panes) open:
+
+- **Board shell** at `<board-home>` for `kanban-md` commands
+- **Worktree shell** at the task worktree for code changes
+
+Do not run multiple mutating `kanban-md` commands in parallel against the same board directory.
+
+If you are unsure you’re using the shared board, run `kanban-md board --compact` and confirm the board name/shape is what you expect.
+
+## Defer-to-User Boundary (exceptions)
+
+By default, agents should take tasks all the way to `done` (worktree → commit → merge → done).
+
+Defer to the user (leave the task in `review` with a handoff) only when you need:
+
+- an important product/spec decision with multiple valid options and no clear winner
+- credentials/access or external actions (push to remote, releases, deployments, ENV variables, etc.)
+- a merge conflict that requires judgment (not just mechanical resolution)
+- repeated test/lint failures you can’t resolve
+
+## Agent Identity (for claims)
+
+Each agent session must generate a unique name to identify itself for claims. At the very start of a session, run:
+
+```bash
+kanban-md agent-name
+```
+
+This produces a name like `quiet-storm` or `frost-maple`. **Remember this name in your context** and use it as a literal string in all claim/release commands for the rest of the session. Do not store it in a file or environment variable — those are not persistent or isolated between agents.
+
+Example: if the generated name is `frost-maple`, use `--claim frost-maple` in every claim command.
+
+## Default Loop (worktree → merge → done)
+
+Use `--compact` for board/list/log output whenever available to keep output short.
+
+Before picking work, ensure board home is on `main`:
+
+```bash
+cd <board-home>
+git switch main
+git status
+```
+
+### 1) Pick and claim (atomically)
+
+From board home:
+
+Pick only from startable columns to avoid accidentally re-picking `review` work:
+
+```bash
+kanban-md pick --claim <agent> --status todo --move in-progress
+```
+
+If `todo` is empty:
+
+```bash
+kanban-md pick --claim <agent> --status backlog --move in-progress
+```
+
+This is atomic — if another agent claims the task between your list and claim, `pick` handles it safely. No need to list/choose/claim manually.
+
+After picking, read the full task:
+
+```bash
+kanban-md show <ID>
+```
+
+### 2) Create a worktree (default)
+
+Create a worktree for the task branch from board home:
+
+```bash
+git worktree add ../kanban-md-task-<ID> -b task/<ID>-<kebab-description>
+cd ../kanban-md-task-<ID>
+```
+
+Skip a worktree only for truly non-conflicting work (e.g., board-only changes or writing an untracked research report). If you touch tracked code/config, use a worktree.
+
+### 3) Implement, test, commit (in the worktree)
+
+Implement the smallest change that satisfies the task.
+
+- Bugs: write a failing test first (TDD), then fix.
+- Run the appropriate checks for the change (common defaults):
+  - `go test ./...`
+  - `golangci-lint run ./...`
+
+Commit in the worktree when green:
+
+```bash
+git add <files>
+git commit -m "feat: <description>"
+```
+
+### Progress notes (recommended)
+
+While a task is `in-progress`, leave short timestamped notes in the task body from **board home** (especially after major steps or before/after running tests). This makes handoffs and reviews much faster.
+
+```bash
+kanban-md edit <ID> --append-body "Implemented X/Y/Z, now running tests." --timestamp --claim <agent>
+```
+
+The `--append-body` (`-a`) flag appends text to the existing body without replacing it. The `--timestamp` (`-t`) flag prefixes a timestamp line like `[[2026-02-10]] Mon 15:04`.
+
+### 4) Merge to main (from board home)
+
+Switch back to board home and merge your task branch:
+
+```bash
+cd <board-home>
+git switch main
+git status
+```
+
+If `git status` shows unexpected changes outside the board directory (usually `kanban/`) or a git operation in progress, do not proceed. Park the task in `review` and move on.
+
+Merge and re-run tests on main:
+
+```bash
+git merge task/<ID>-<kebab-description>
+go test ./...
+golangci-lint run ./...
+```
+
+If you cannot merge right now (e.g., another merge/rebase is in progress), do **not** force. Park the task in `review`, leave a note (branch name + what’s left), and pick the next task.
+
+To park a “ready to merge” task:
+
+From board home:
+
+```bash
+kanban-md handoff <ID> --claim <agent> --note "Ready to merge: task/<ID>-…; remaining: …" --timestamp --release
+```
+
+### 5) Mark done (only after merge)
+
+Only after the merge is on main and checks pass:
+
+From board home:
+
+```bash
+kanban-md edit <ID> --release
+kanban-md move <ID> done
+```
+
+### 6) Commit board changes (only if board is git-tracked)
+
+From board home:
+
+```bash
+git add kanban/config.yml kanban/tasks/
+git commit -m "chore(board): update task #<ID>"
+```
+
+### 7) Optional cleanup
+
+```bash
+git worktree remove --force ../kanban-md-task-<ID>
+git branch -d task/<ID>-<kebab-description>
+```
+
+## Blocked / Needs User Input (the “review and move on” rule)
+
+If you cannot continue without the user (decision, access, environment, or anything outside your control):
+
+From board home:
+
+```bash
+kanban-md handoff <ID> --claim <agent> \
+  --block "Waiting on user: <what you need>" \
+  --note "## Handoff
+- Current state:
+- Branch (if any):
+- Open questions (A/B):
+- Next step:" \
+  --timestamp --release
+```
+
+In your handoff note, include:
+
+- The exact question(s) for the user (prefer A/B options)
+- What you already tried and what happened
+- The minimal next step after the user responds
+
+Then pick the next task. Do not idle.
+
+## Resuming a parked task
+
+When the user answers and you need to continue, re-claim and move back to `in-progress`:
+
+From board home:
+
+```bash
+kanban-md edit <ID> --claim <agent>
+kanban-md edit <ID> --unblock --claim <agent>   # if it was blocked
+kanban-md move <ID> in-progress --claim <agent>
+```
+
+## Status meanings (keep the board honest)
+
+| Status | Meaning |
+|---|---|
+| `in-progress` | Actively being worked by an agent right now |
+| `review` | Waiting state: ready to merge, or waiting on user/decision/unblock |
+| `done` | Merged to main (and checks pass) |
+
+## When there is nothing to pick
+
+If `pick` returns "no unblocked, unclaimed tasks found":
+
+- Check blocked work: `kanban-md list --compact --blocked`
+- Check waiting work: `kanban-md list --compact --status review`
+- If everything is waiting on the user, ask targeted questions and stop (don't thrash the board).

--- a/.claude/skills/kanban-md/SKILL.md
+++ b/.claude/skills/kanban-md/SKILL.md
@@ -1,0 +1,363 @@
+---
+name: kanban-md
+description: >
+  Manage project tasks using kanban-md, a file-based kanban board CLI.
+  Use when the user mentions tasks, kanban, board, backlog, sprint,
+  project management, work items, priorities, blockers, or wants to
+  track, create, list, move, edit, or delete tasks. Also use for
+  standup, status update, sprint planning, triage, or project metrics.
+allowed-tools:
+  - Bash(kanban-md *)
+  - Bash(kbmd *)
+---
+<!-- kanban-md-skill-version: dev -->
+
+# kanban-md
+
+Manage kanban boards stored as Markdown files with YAML frontmatter.
+Each task is a `.md` file in `kanban/tasks/`. The CLI is `kanban-md`
+(alias `kbmd` if installed via Homebrew).
+
+## Current Board State
+
+!`kanban-md board 2>/dev/null || echo 'No board found — run: kanban-md init --name PROJECT_NAME'`
+
+## Rules
+
+- Use `--compact` for listing commands (`list`, `board`, `metrics`, `log`) to get
+  token-efficient one-line output.
+- Use `kanban-md show ID` (default table format) to read task details — it includes
+  the full body and all fields in a human-readable layout. Only add `--json` when you
+  need to pipe the output to another tool or parse fields programmatically.
+- Always pass `--yes` when deleting (`kanban-md delete ID --yes`).
+- Dates use `YYYY-MM-DD` format.
+- Statuses and priorities are board-specific. Check the board state above or run
+  `kanban-md board` to discover valid values before using them.
+- Default statuses: backlog, todo, in-progress, review, done.
+- Default priorities: low, medium, high, critical.
+
+## Decision Tree
+
+| User wants to...                        | Command                                                          |
+|-----------------------------------------|------------------------------------------------------------------|
+| See board overview / standup            | `kanban-md board --compact`                                      |
+| Get a unique agent name (for claims)    | `kanban-md agent-name`                                           |
+| List all tasks                          | `kanban-md list --compact`                                       |
+| List tasks by status                    | `kanban-md list --compact --status todo,in-progress`             |
+| List tasks by priority                  | `kanban-md list --compact --priority high,critical`              |
+| List tasks by assignee                  | `kanban-md list --compact --assignee alice`                      |
+| List tasks by tag                       | `kanban-md list --compact --tag bug`                             |
+| List blocked tasks                      | `kanban-md list --compact --blocked`                             |
+| List ready-to-start tasks               | `kanban-md list --compact --not-blocked --status todo`           |
+| List tasks with resolved deps           | `kanban-md list --compact --unblocked`                           |
+| Find a specific task                    | `kanban-md show ID`                                              |
+| Claim next available task               | `kanban-md pick --claim <agent> --status todo --move in-progress`|
+| Create a task                           | `kanban-md create "TITLE" --priority P --tags T`                 |
+| Create a task with body                 | `kanban-md create "TITLE" --body "DESC"`                         |
+| Create and immediately claim a task     | `kanban-md create "TITLE" --priority P --claim <agent>`          |
+| Start working on a task                 | `kanban-md move ID in-progress`                                  |
+| Advance to next status                  | `kanban-md move ID --next`                                       |
+| Move a task back                        | `kanban-md move ID --prev`                                       |
+| Complete a task                         | `kanban-md move ID done`                                         |
+| Edit task fields                        | `kanban-md edit ID --title "NEW" --priority P`                   |
+| Add/remove tags                         | `kanban-md edit ID --add-tag T --remove-tag T`                   |
+| Set a due date                          | `kanban-md edit ID --due 2026-03-01`                             |
+| Block a task                            | `kanban-md edit ID --block "REASON"`                             |
+| Unblock a task                          | `kanban-md edit ID --unblock`                                    |
+| Add a dependency                        | `kanban-md edit ID --add-dep DEP_ID`                             |
+| Set a parent task                       | `kanban-md edit ID --parent PARENT_ID`                           |
+| Append a note to task body              | `kanban-md edit ID --append-body "note" --timestamp`             |
+| Hand off a task to review               | `kanban-md handoff ID --claim <agent> --note "…" --release`      |
+| Delete a task                           | `kanban-md delete ID --yes`                                      |
+| See flow metrics                        | `kanban-md metrics --compact`                                    |
+| See activity log                        | `kanban-md log --compact --limit 20`                             |
+| See recent activity for a task          | `kanban-md log --compact --task ID`                              |
+| Get a board context summary             | `kanban-md context`                                              |
+| Initialize a new board                  | `kanban-md init --name "NAME"`                                   |
+
+## Core Commands
+
+### list
+
+```bash
+kanban-md list [--status S] [--priority P] [--assignee A] [--tag T] \
+  [--sort FIELD] [-r] [-n LIMIT] [--blocked] [--not-blocked] \
+  [--parent ID] [--unblocked]
+```
+
+Sort fields: id, status, priority, created, updated, due. `-r` reverses.
+`--unblocked` shows tasks whose dependencies are all at terminal status.
+
+### create
+
+```bash
+kanban-md create "TITLE" [--status S] [--priority P] [--assignee A] \
+  [--tags T1,T2] [--due YYYY-MM-DD] [--estimate E] [--body "TEXT"] \
+  [--parent ID] [--depends-on ID1,ID2] [--claim AGENT]
+```
+
+Prints the created task ID and summary. `--claim` immediately claims the task for an agent,
+combining creation and claiming in one step.
+
+### show
+
+```bash
+kanban-md show ID
+kanban-md show ID --json   # only when piping to another tool
+```
+
+Default format shows all fields including the body in a readable layout.
+Use `--json` only when you need to parse fields programmatically.
+For the JSON schema, see [references/json-schemas.md](references/json-schemas.md).
+
+### agent-name
+
+```bash
+kanban-md agent-name
+```
+
+Generates a random two-word identifier (e.g. `frost-maple`) to use as a claim name.
+Run once per agent session and remember the result.
+
+### edit
+
+```bash
+kanban-md edit ID[,ID,...] [--title T] [--status S] [--priority P] [--assignee A] \
+  [--add-tag T] [--remove-tag T] [--due YYYY-MM-DD] [--clear-due] \
+  [--estimate E] [--body "TEXT"] [-a "TEXT"] [--started YYYY-MM-DD] [--clear-started] \
+  [--completed YYYY-MM-DD] [--clear-completed] [--parent ID] \
+  [--clear-parent] [--add-dep ID] [--remove-dep ID] \
+  [--block "REASON"] [--unblock] \
+  [--claim AGENT] [--release] [-t]
+```
+
+Only specified fields are changed. Prints a confirmation message.
+`-a` / `--append-body` appends text to the existing body without replacing it.
+`-t` / `--timestamp` prefixes a timestamp line when appending.
+`--claim` claims (or renews a claim on) the task for the agent.
+`--release` releases the claim on the task.
+Accepts comma-separated IDs for bulk edits.
+
+### move
+
+```bash
+kanban-md move ID[,ID,...] STATUS
+kanban-md move ID --next
+kanban-md move ID --prev
+kanban-md move ID STATUS --claim AGENT
+```
+
+Auto-sets Started on first move from initial status. Auto-sets Completed on move to terminal status.
+Accepts comma-separated IDs for bulk moves. `--claim` claims the task during the move (useful when
+resuming a parked task).
+
+### pick
+
+```bash
+kanban-md pick --claim AGENT [--status S] [--move STATUS] [--tags T1,T2]
+```
+
+Atomically finds the highest-priority unclaimed, unblocked task and claims it. Use `--status` to
+restrict which column to pick from. Use `--move` to simultaneously move the task to a new status.
+Replaces the slower list → claim → move sequence.
+
+### handoff
+
+```bash
+kanban-md handoff ID --claim AGENT [--note "TEXT"] [--block "REASON"] [--release] [-t]
+```
+
+Moves the task to `review`, appends a handoff note, and optionally marks it blocked and/or releases
+the claim. Use when parking work for another agent or waiting on user input. `-t` adds a timestamp.
+
+### context
+
+```bash
+kanban-md context [--sections in-progress,blocked,overdue,recently-completed] \
+  [--days N] [--write-to FILE]
+```
+
+Generates a markdown board summary suitable for embedding in `CLAUDE.md` or `AGENTS.md`.
+`--write-to` writes (or updates) the summary inside a delimited block in the target file.
+
+### delete
+
+```bash
+kanban-md delete ID --yes
+```
+
+Always pass `--yes` (non-interactive context requires it).
+
+### board
+
+```bash
+kanban-md board
+```
+
+Shows board overview: task counts per status, WIP utilization,
+blocked/overdue counts, priority distribution.
+
+### metrics
+
+```bash
+kanban-md metrics [--since YYYY-MM-DD]
+```
+
+Shows throughput (7d/30d), avg lead/cycle time, flow efficiency,
+aging items.
+
+### log
+
+```bash
+kanban-md log [--since YYYY-MM-DD] [--limit N] [--action TYPE] \
+  [--task ID]
+```
+
+Action types: create, move, edit, delete, block, unblock.
+
+### Global Flags
+
+All commands accept: `--json`, `--table`, `--compact` (alias `--oneline`), `--dir PATH`, `--no-color`.
+
+## Workflows
+
+### Daily Standup
+
+1. `kanban-md board --compact` — board overview
+2. `kanban-md list --compact --status in-progress` — in-flight work
+3. `kanban-md list --compact --blocked` — stuck items
+4. `kanban-md metrics --compact` — throughput and aging
+5. Summarize: completed, active, blocked, aging items
+
+### Triage New Work
+
+1. `kanban-md list --compact --status backlog --sort priority -r` — review backlog
+2. For items to promote: `kanban-md move ID todo`
+3. For new items: `kanban-md create "TITLE" --priority P --tags T`
+4. For stale items: `kanban-md delete ID --yes`
+
+### Sprint Planning
+
+1. `kanban-md board --compact` — current state
+2. `kanban-md list --compact --status backlog,todo --sort priority -r` — candidates
+3. Promote selected: `kanban-md move ID todo`
+4. Assign: `kanban-md edit ID --assignee NAME`
+5. Set deadlines: `kanban-md edit ID --due YYYY-MM-DD`
+
+### Complete a Task
+
+1. `kanban-md move ID done` — marks complete, sets Completed timestamp
+2. `kanban-md show ID --json` — verify status and timestamps
+
+### Track a Bug
+
+1. `kanban-md create "Fix: DESCRIPTION" --priority high --tags bug`
+2. `kanban-md edit ID --body "Steps to reproduce: ..."`
+
+### Track a Dependency Chain
+
+1. Create parent: `kanban-md create "Epic title"`
+2. Create subtask: `kanban-md create "Subtask" --parent PARENT_ID`
+3. Or add dependency: `kanban-md create "Task B" --depends-on TASK_A_ID`
+4. List unresolved: `kanban-md list --compact --blocked`
+
+## Agent Cheatsheet
+
+Quick-reference for the agent task lifecycle. These are combination commands — multiple flags
+in one call to minimize round-trips. Replace `<agent>` with your session's `agent-name` output.
+
+### Session start
+
+```bash
+kanban-md agent-name                             # generate a unique claim name; remember it
+kanban-md board --compact                        # orient: what's active, blocked, overdue
+```
+
+### Claim next task (atomic pick + move)
+
+```bash
+# Pick highest-priority unclaimed task from todo and move it to in-progress in one step
+kanban-md pick --claim <agent> --status todo --move in-progress
+
+# If todo is empty, pick from backlog
+kanban-md pick --claim <agent> --status backlog --move in-progress
+
+# Read the full task after picking
+kanban-md show <ID>
+```
+
+### Create and claim in one shot
+
+```bash
+# Create a task and immediately claim it
+kanban-md create "TITLE" --priority high --tags bug --claim <agent>
+
+# Add a body separately (or use --body inline if short)
+kanban-md edit <ID> --body "Steps to reproduce: ..."
+```
+
+### Progress note (renews claim, appends without overwriting)
+
+```bash
+# Leave a timestamped note while keeping your claim active
+kanban-md edit <ID> -a "Implemented X, running tests." -t --claim <agent>
+```
+
+### Finish task (release claim + mark done)
+
+```bash
+# Run from board home, after merging
+kanban-md edit <ID> --release
+kanban-md move <ID> done
+```
+
+### Park / handoff (moves to review, appends note, releases claim)
+
+```bash
+# Waiting on user decision or external action
+kanban-md handoff <ID> --claim <agent> \
+  --note "Ready to merge: branch task/<ID>-…; waiting for: ..." \
+  -t --release
+
+# Blocked on something specific
+kanban-md handoff <ID> --claim <agent> \
+  --block "Reason for block" \
+  --note "What's needed to unblock and next step." \
+  -t --release
+```
+
+### Resume a parked task
+
+```bash
+kanban-md edit <ID> --claim <agent>                  # re-claim
+kanban-md edit <ID> --unblock --claim <agent>        # unblock (if it was blocked)
+kanban-md move <ID> in-progress --claim <agent>      # move back to in-progress
+```
+
+### Bulk operations (comma-separated IDs)
+
+```bash
+# Tag multiple tasks at once
+kanban-md edit <ID1>,<ID2>,<ID3> --add-tag layer-3
+
+# Move multiple tasks
+kanban-md move <ID1>,<ID2> todo
+
+# List with combined filters
+kanban-md list --compact --status backlog --priority high,critical --sort priority -r
+kanban-md list --compact --not-blocked --status todo   # tasks ready to start
+kanban-md list --compact --status in-progress,review   # all active/parked work
+```
+
+## Pitfalls
+
+- **DO** use `--compact` for listing, board, metrics, and log commands — it is the most token-efficient format.
+- **DO** use `kanban-md show ID` (default format) to read task details — it is readable and includes the full body.
+- **DO** pass `--yes` on delete. Without it, the command hangs waiting for stdin.
+- **DO** use `pick --claim <agent> --status todo --move in-progress` rather than list → edit → move — it's atomic and prevents claim races.
+- **DO** use `-a` / `--append-body` with `--claim <agent>` when adding progress notes — this renews the claim and appends without overwriting the body.
+- **DO NOT** use `--json` unless you are piping output to another tool or parsing fields programmatically. Default and `--compact` formats are sufficient for reading.
+- **DO NOT** hardcode status or priority values. Read them from `kanban-md board --compact`.
+- **DO NOT** use `--next` or `--prev` without checking current status. They fail at boundary statuses.
+- **DO NOT** pass both `--status` and `--next`/`--prev` to move. Use one or the other.
+- **DO** quote task titles with special characters: `kanban-md create "Fix: the 'login' bug"`.

--- a/.claude/skills/kanban-md/references/json-schemas.md
+++ b/.claude/skills/kanban-md/references/json-schemas.md
@@ -1,0 +1,54 @@
+# kanban-md JSON Output Schemas
+
+Reference for parsing `show --json` output and error responses.
+
+## Task Object
+
+Returned by: `show --json` (also by other commands when `--json` is passed).
+
+```json
+{
+  "id": 1,
+  "title": "Task title",
+  "status": "in-progress",
+  "priority": "high",
+  "created": "2026-02-07T10:30:00Z",
+  "updated": "2026-02-07T11:00:00Z",
+  "started": "2026-02-07T10:35:00Z",
+  "completed": "2026-02-07T12:00:00Z",
+  "assignee": "alice",
+  "tags": ["bug", "frontend"],
+  "due": "2026-03-01",
+  "estimate": "4h",
+  "parent": 5,
+  "depends_on": [3, 4],
+  "blocked": true,
+  "block_reason": "Waiting on API keys",
+  "body": "Markdown body text",
+  "file": "kanban/tasks/001-task-title.md"
+}
+```
+
+Fields with `omitempty` (absent when zero/null): started, completed,
+assignee, tags, due, estimate, parent, depends_on, blocked, block_reason,
+body, file.
+
+## Error Response
+
+Returned on errors when `--json` is active:
+
+```json
+{
+  "error": "task not found",
+  "code": "TASK_NOT_FOUND",
+  "details": {"id": 99}
+}
+```
+
+Error codes: TASK_NOT_FOUND, BOARD_NOT_FOUND, BOARD_ALREADY_EXISTS,
+INVALID_INPUT, INVALID_STATUS, INVALID_PRIORITY, INVALID_DATE,
+INVALID_TASK_ID, WIP_LIMIT_EXCEEDED, DEPENDENCY_NOT_FOUND,
+SELF_REFERENCE, NO_CHANGES, BOUNDARY_ERROR, STATUS_CONFLICT,
+CONFIRMATION_REQUIRED, INTERNAL_ERROR.
+
+Exit codes: 1 for user errors, 2 for internal errors.

--- a/.gitignore
+++ b/.gitignore
@@ -51,3 +51,9 @@ app.*.map.json
 key.properties
 *.jks
 *.keystore
+
+# Claude Code – machine-local (Permissions enthalten Wildcards, nie einchecken)
+.claude/settings.local.json
+
+# Kanban – Laufzeit-Lock (kein versionierbarer Board-State)
+kanban/.lock

--- a/kanban/activity.jsonl
+++ b/kanban/activity.jsonl
@@ -1,0 +1,7 @@
+{"timestamp":"2026-06-01T16:52:37.871586603+02:00","action":"create","task_id":1,"detail":"Android-Release-Build reparieren (CI assembleRelease schlägt fehl)"}
+{"timestamp":"2026-06-02T11:54:50.500663795+02:00","action":"claim","task_id":1,"detail":"falcon-midge"}
+{"timestamp":"2026-06-02T11:54:50.501303797+02:00","action":"move","task_id":1,"detail":"todo -\u003e in-progress"}
+{"timestamp":"2026-06-02T12:03:01.559924912+02:00","action":"edit","task_id":1,"detail":"Android-Release-Build reparieren (CI assembleRelease schlägt fehl)"}
+{"timestamp":"2026-06-02T14:08:40.991801773+02:00","action":"move","task_id":1,"detail":"in-progress -\u003e review"}
+{"timestamp":"2026-06-02T14:08:40.992278275+02:00","action":"handoff","task_id":1,"detail":"Android-Release-Build reparieren (CI assembleRelease schlägt fehl)"}
+{"timestamp":"2026-06-02T14:08:40.992306475+02:00","action":"release","task_id":1,"detail":"Android-Release-Build reparieren (CI assembleRelease schlägt fehl)"}

--- a/kanban/config.yml
+++ b/kanban/config.yml
@@ -1,0 +1,47 @@
+version: 10
+board:
+    name: Kailibrate
+tasks_dir: tasks
+statuses:
+    - name: backlog
+      show_duration: false
+    - name: todo
+    - name: in-progress
+      require_claim: true
+    - name: review
+      require_claim: true
+    - name: done
+      show_duration: false
+    - name: archived
+      show_duration: false
+priorities:
+    - low
+    - medium
+    - high
+    - critical
+defaults:
+    status: backlog
+    priority: medium
+    class: standard
+claim_timeout: 1h
+classes:
+    - name: expedite
+      wip_limit: 1
+      bypass_column_wip: true
+    - name: fixed-date
+    - name: standard
+    - name: intangible
+tui:
+    title_lines: 2
+    age_thresholds:
+        - after: 0s
+          color: "242"
+        - after: 1h
+          color: "34"
+        - after: 24h
+          color: "226"
+        - after: 72h
+          color: "208"
+        - after: 168h
+          color: "196"
+next_id: 2

--- a/kanban/tasks/001-android-release-build-reparieren-ci.md
+++ b/kanban/tasks/001-android-release-build-reparieren-ci.md
@@ -1,0 +1,71 @@
+---
+id: 1
+title: Android-Release-Build reparieren (CI assembleRelease schlägt fehl)
+status: review
+priority: high
+created: 2026-06-01T16:52:37.870206318+02:00
+updated: 2026-06-02T14:08:40.991631472+02:00
+tags:
+    - build
+    - ci
+    - android
+class: standard
+---
+
+## Kontext
+
+Der Push des Tags **v1.7.1-beta.1** hat den CI-Release-Workflow ausgelöst;
+`flutter build apk --release` (`assembleRelease`) ist fehlgeschlagen.
+Fehlgeschlagener Run: GitHub Actions "Release" #26761023987.
+
+## Ursache
+
+Der CI nutzt `subosito/flutter-action@v2` mit `channel: stable` **ohne Versions-Pin**
+→ floatet aktuell auf **Flutter 3.44.0**. Diese Version erzwingt Kotlin >= 2.0.
+Das Projekt hatte aber ein totes Legacy-`buildscript` mit `kotlin 1.9.22`.
+Beim Weiterbauen folgte ein zweiter Fehler: neue transitive AndroidX-Deps
+(`androidx.core 1.17.0`, `core-ktx 1.17.0`, `browser 1.9.0`) verlangen AGP >= 8.9.1.
+
+## Bereits erledigt (lokal, UNCOMMITTED, Branch chore/misc-fixes-and-features)
+
+1. android/build.gradle: Legacy-`buildscript`-Block entfernt
+   (ext.kotlin_version 1.9.22 + classpath gradle:8.2.2 + kotlin-gradle-plugin).
+   → Kotlin-Quelle ist jetzt allein settings.gradle (2.1.0). Kotlin-Fehler verschwand.
+2. android/settings.gradle: AGP 8.7.0 -> 8.11.1.
+3. android/gradle/wrapper/gradle-wrapper.properties: Gradle 8.10.2 -> 8.14.
+
+## Offen (morgen)
+
+- [ ] Build verifizieren: `/home/kai/flutter/bin/flutter build apk --debug`
+      lokal grün bekommen (bestaetigt, dass AGP 8.11.1 + Gradle 8.14 die
+      AAR-Metadata-Fehler loest). Achtung: lokales Flutter ist 3.41.4, CI 3.44.0.
+      Der Gradle-8.14-Download (~150 MB) macht den ersten Lauf langsam.
+- [ ] Optional aber empfohlen: Flutter-Version im CI pinnen
+      (.github/workflows/release.yml, flutter-action `flutter-version:`),
+      um kuenftiges Floaten von `stable` als Bruchquelle auszuschliessen.
+      Tradeoff mit Kai besprechen (Pin vs. immer-aktuell).
+- [ ] Android-Gradle-Fixes committen (getrennt vom Lizenz-Commit).
+      Pruefen: gradlew, gradle-wrapper.jar, android/app/.cxx/ waren zu
+      Session-Beginn UNTRACKED — gehoeren wrapper-Dateien committed?
+- [ ] Fehlgeschlagenes Release v1.7.1-beta.1 bereinigen: Tag ist gepusht,
+      Release-Workflow rot -> kein APK am GitHub-Release. Nach gemergtem Fix
+      entweder Workflow neu starten oder Tag loeschen + neu setzen.
+- [ ] PR #97 (Lizenz + Changelog) gegen main ist offen. Entscheiden, ob der
+      Gradle-Fix in denselben PR oder einen eigenen geht, bevor neu released wird.
+
+## Verifikation
+
+- `flutter build apk --debug` ohne BUILD FAILED
+- Idealerweise `flutter build apk --release` (braucht Keystore: android/app/key.properties)
+- Danach: neuer Release-Lauf erzeugt kailibrate-vX.apk am GitHub-Release
+
+## Bewusst ausgelassen
+
+pubspec.lock (modifiziert) und untracked android/-Build-Artefakte sind NICHT Teil
+der Aenderungen und blieben aussen vor.
+
+[[2026-06-02]] Tue 12:03
+Build verifiziert: flutter build apk --debug erfolgreich (✓ Built app-debug.apk, exit 0). AGP 8.11.1 + Gradle 8.14 loesen die AAR-Metadata-Fehler. .cxx/ zu .gitignore hinzugefuegt.
+
+[[2026-06-02]] Tue 14:08
+Build-Fix fertig & gepusht (Commit c5fa3d4) auf chore/misc-fixes-and-features -> PR #97 (mergeable). Debug-Build lokal gruen. Entscheidungen mit Kai: Fix geht in PR #97; Flutter NICHT gepinnt (release.yml unangetastet); Release-Tag v1.7.1-beta.1 raeumt Kai selbst nach Merge auf. OFFEN fuer Kai: (1) PR #97 mergen, (2) danach Tag v1.7.1-beta.1 neu setzen oder Release-Workflow re-runnen, damit das APK am GitHub-Release erscheint.


### PR DESCRIPTION
## Summary

Bring the kanban-based development workflow under version control so it is reproducible across machines, while keeping machine-local artifacts out of the repo.

**Tracked:**
- `kanban/` board — `config.yml`, `tasks/`, `activity.jsonl`
- `.claude/skills/` — `kanban-md` and `kanban-based-development` skills

**Excluded via `.gitignore`:**
- `.claude/settings.local.json` — machine-local permissions (contains wildcards; never check in)
- `kanban/.lock` — transient runtime lock

## Notes

- `pubspec.lock` changes from the local session were **deliberately discarded** — they were regenerated with local Flutter 3.41.4 while CI runs 3.44.0, and task #1 had already excluded them. A clean lock should be regenerated against the CI SDK if/when needed.
- `kanban/activity.jsonl` is an append-only log; included for audit trail. Flag if it causes merge friction later.

🤖 Generated with [Claude Code](https://claude.com/claude-code)